### PR TITLE
Fix username github context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   username:
     description: 'The username for git configuration'
     required: false
-    default: ${{ github.event.issue.user.login }}
+    default: ${{ github.actor }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Since the trigger to this workflow isn't an issue, `githhub.event.issue` will be null – I believe it should be `github.actor` (https://docs.github.com/en/actions/learn-github-actions/contexts)