### PR TITLE
Replace node12 action with node16 action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
     with:
       repo: pulumi/pulumictl
   - name: Install Pulumi CLI
-    uses: pulumi/action-install-pulumi-cli@v2
+    uses: pulumi/actions@v4
   - name: Checkout repo
     uses: actions/checkout@v3
     with:


### PR DESCRIPTION
Github Actions phased out support for Node 12 actions.

Replacing the old `node12` action with our main updated `node16` action which also [supports installation only](https://github.com/pulumi/actions#installation-only).