### PR TITLE
Add email input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 'The username for git configuration'
     required: false
     default: ${{ github.actor }}
+  email:
+    description: 'The email for git configuration'
+    required: false
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,12 @@ runs:
     uses: gradle/gradle-build-action@v2
     with:
       gradle-version: "7.6"
-  - name: Set up git identity
+  - name: "Set up git identity: name"
     run: git config --global user.name '${{ inputs.username }}'
+    shell: bash
+  - name: "Set up git identity: email"
+    if: ${{ inputs.email != '' }}
+    run: git config --global user.email '${{ inputs.email }}'
     shell: bash
   - name: Run upgrade-provider
     run: upgrade-provider ${{ github.repository }} --kind=${{ inputs.kind }}


### PR DESCRIPTION
Explicitly configure name and email for git.

I haven't found a failing upgrade that hasn't been fixed at this point, but this should fix (needs to be consumed) https://github.com/pulumi/upgrade-provider/issues/144. Since this is backwards compatible, I would like to merge this then push it through ci-mgmt to all of our providers.
We have tested that this sets email for `git`.