### PR TITLE
Only merge when told

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
     env:
       GH_TOKEN: ${{ env.GH_TOKEN }}
   - name: Set PR to auto-merge
-    if: ${{ inputs.automerge }}
+    if: ${{ inputs.automerge == 'true' }}
     # This tolerates repos that do not have auto-merge enabled.  `continue-on-error: true`
     # should be removed when https://github.com/pulumi/home/issues/3140 closes.
     continue-on-error: true


### PR DESCRIPTION
We are seeing provider's merge without review or release. I believe it is because
`automerge` is set to `"false"`, which is truthy.

GitHub Actions don't mention a `type` field for composite action's inputs, which makes me
afraid this is just a string. This is substantiated by https://github.com/actions/runner/issues/2238.