### PR TITLE
Only pass vars when they are set to a non "" value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
     shell: bash
   - name: Run upgrade-provider
     run: |
-      upgrade-provider "$REPO" --kind="$KIND" --target-bridge-version="$TBV" --pr-reviewers="$REV" --pr-description="$DESC"
+      upgrade-provider "$REPO" --kind="$KIND" ${TBV:+--target-bridge-version="$TBV"} ${REV:+--pr-reviewers="$REV"} ${DESC:+--pr-description="$DESC"}
     shell: bash
     env:
       GH_TOKEN: ${{ env.GH_TOKEN }}


### PR DESCRIPTION
The bash syntax `${X:+Y}` means expand to Y when X is set and non-null.