### PR TITLE
Allow rewriting code as part of upgrading providers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,9 @@ runs:
     if: ${{ inputs.email != '' }}
     run: git config --global user.email '${{ inputs.email }}'
     shell: bash
+  - name: Apply patches
+    run: go run github.com/uber-go/gopatch@latest --patch patches/bridge-imports.patch -v ./...
+    shell: bash
   - name: Run upgrade-provider
     run: |
       upgrade-provider "$REPO" --kind="$KIND" ${TBV:+--target-bridge-version="$TBV"} ${REV:+--pr-reviewers="$REV"} ${DESC:+--pr-description="$DESC"} ${PREF:+--pr-title-prefix="$PREF"} ${PUV:+--target-pulumi-version="$PUV"} ${JV:+--java-version="$JV"}

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,3 @@
+This directory contains [gopatch](https://github.com/uber-go/gopatch) files for automated code refactoring.
+
+The syntax of these patches is described in detail [here](https://github.com/uber-go/gopatch/blob/main/docs/PatchesInDepth.md).

--- a/patches/bridge-imports.patch
+++ b/patches/bridge-imports.patch
@@ -1,0 +1,48 @@
+@@
+var alias identifier
+@@
+-import alias "github.com/pulumi/pulumi-terraform-bridge/pf"
++import alias "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf"
+
+ alias
+
+@@
+var alias identifier
+@@
+-import alias "github.com/pulumi/pulumi-terraform-bridge/pf/proto"
++import alias "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/proto"
+
+ alias
+
+@@
+var alias identifier
+@@
+-import alias "github.com/pulumi/pulumi-terraform-bridge/pf/tfgen"
++import alias "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
+
+ alias
+
+@@
+var alias identifier
+@@
+-import alias "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
++import alias "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+
+ alias
+
+@@
+var alias identifier
+@@
+-import alias "github.com/pulumi/pulumi-terraform-bridge/testing/x"
++import alias "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/testing"
+
+ alias
+
+@@
+var alias identifier
+@@
+-import alias "github.com/pulumi/pulumi-terraform-bridge/x/muxer"
++import alias "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/muxer"
+
+ alias
+


### PR DESCRIPTION
This enables us to apply some patches as part of the automated upgrade process.

Our initial patch applies the new imports introduced in https://github.com/pulumi/pulumi-terraform-bridge/pull/2480. Obviously this PR should not be released until that one is in.

Refs https://github.com/pulumi/pulumi-terraform-bridge/pull/2473
Refs https://github.com/pulumi/pulumi-terraform-bridge/issues/1445