### PR TITLE
Upgrade gradle-build-action to match ci-mgmt version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,9 +105,11 @@ runs:
     run: go install github.com/pulumi/upgrade-provider@main
     shell: bash
   - name: Setup Gradle
-    uses: gradle/gradle-build-action@v2
+    # Taken from ci-mgmt: https://github.com/pulumi/ci-mgmt/blob/cbb506c8323134f33314a4877d8cd305b127d6da/provider-ci/internal/pkg/action-versions.yml#L34
+    uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
     with:
       gradle-version: "7.6"
+
   - name: "Set up git identity: name"
     run: git config --global user.name '${{ inputs.username }}'
     shell: bash


### PR DESCRIPTION
Relates: https://github.com/pulumi/pulumi-upgrade-provider-action/issues/39

