### PR TITLE
Echo upgrade-provider command for easier debugging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,6 +119,7 @@ runs:
     shell: bash
   - name: Run upgrade-provider
     run: |
+      set -x
       upgrade-provider "$REPO" --kind="$KIND" ${TBV:+--target-bridge-version="$TBV"} ${REV:+--pr-reviewers="$REV"} ${DESC:+--pr-description="$DESC"} ${PREF:+--pr-title-prefix="$PREF"} ${PUV:+--target-pulumi-version="$PUV"} ${JV:+--java-version="$JV"} ${TPV:+--target-version="$TPV"} ${AM:+--allow-missing-docs="$AM"}
     shell: bash
     env:


### PR DESCRIPTION
If we fail to create a PR the operator needs to manually piece together all the relevant env vars to figure out what command was actually executed.

Instead let's just echo the command with env vars expanded to make it copy-paste-able.