### PR TITLE
Fix checkout auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,8 +90,9 @@ runs:
   - name: Install Pulumi CLI
     uses: pulumi/actions@v4
   - name: Checkout repo
-    uses: actions/checkout@v3
+    uses: actions/checkout@v6
     with:
+      token: ${{ env.GH_TOKEN }}
       ref: ${{ github.ref_name }}
   - name: Install Go using version file if specified
     if: ${{ inputs.go-version-file != '' }}


### PR DESCRIPTION
Change the call to the checkout action to pass along the environment's
`GH_TOKEN`. This prevents the action from automatically picking up the
action's token.

These changes also update the version of the action to v6.
